### PR TITLE
fix: correct typo on home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,7 +34,7 @@ import Extras from "../components/extras.astro";
 		<div class="instructions w-[100%] py-2 text-left sm:text-justify">
 			<h2 class="head">Get in touch</h2>
 			<p>
-				My inbox is always open. Whether yoou have a question or project
+				My inbox is always open. Whether you have a question or project
 				or just want to say hi. I'll try my best to get back to you!
 			</p>
 			<button class="px-8 py-2 border rounded my-4 btn w-[150px] sm:w-[220px]">Say Hello</button>


### PR DESCRIPTION
Closes issue #1 

Fixes a typo in the text content of the homepage (`index.astro`) where "yoou" was corrected to "you" on line 37.